### PR TITLE
Change change-unit-scan-package to change-logs-scan-package

### DIFF
--- a/site/v5/runner/runner-springboot.md
+++ b/site/v5/runner/runner-springboot.md
@@ -147,7 +147,7 @@ ______________________________________
 ### Example with properties
 ```yaml
 mongock:
-  change-logs-scan-package:
+  migration-scan-package:
     - com.your.migration.package1
     - com.your.migration.package2
   metadata:

--- a/site/v5/runner/runner-springboot.md
+++ b/site/v5/runner/runner-springboot.md
@@ -147,7 +147,7 @@ ______________________________________
 ### Example with properties
 ```yaml
 mongock:
-  change-unit-scan-package:
+  change-logs-scan-package:
     - com.your.migration.package1
     - com.your.migration.package2
   metadata:


### PR DESCRIPTION
If I use `change-unit-scan-package`, Mongock throws an error on startup:

```
Factory method 'applicationRunner' threw exception with message: 
Scan package for changeLogs is not set: use appropriate setter
```

More details in https://github.com/jhipster/generator-jhipster/pull/19791#issuecomment-1320932707. 