### PR TITLE
feat(site): add Google Analytics and Mongock sunsetting notice

### DIFF
--- a/site/_includes/layout/default.njk
+++ b/site/_includes/layout/default.njk
@@ -18,6 +18,15 @@
     <link href="/styles/util.css" rel="stylesheet" />
     <link href="/styles/prism-base16-ateliersulphurpool.light.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Fjalla+One|Roboto" rel="stylesheet" />
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-LJD5X6BDNH"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-LJD5X6BDNH');
+    </script>
   </head>
 
   <body>

--- a/site/v5/what-is-mongock/what-is-mongock.md
+++ b/site/v5/what-is-mongock/what-is-mongock.md
@@ -12,8 +12,22 @@ eleventyNavigation:
     <img src="/images/mongock-logo-with-title.jpg" width="65%" alt="Mongock">
 </p>
 
-<div class="success">
-<b>Mongock 5 released!!</b> Please visit the <a href="/v5/from-version-4-to-5">upgrade page</a> to follow easy process. 
+<div class="warning">
+<b>Mongock is sunsetting — meet <a href="https://flamingock.io" target="_blank" rel="noopener">Flamingock</a>, its open-source successor.</b>
+<br><br>
+Mongock solved a focused problem: safe database evolution. Modern applications rarely evolve databases in isolation — a single domain change often touches multiple systems (database schemas, API contracts, Kafka event definitions, API gateway policies, content models, configuration stores). Flamingock extends Mongock's core principles to that broader scope, with all of Mongock's core functionality fully covered: database migrations, deterministic ordered execution, single-execution guarantee, and auditable ledger.
+<br><br>
+Mongock will continue receiving <b>critical bug fixes and security updates only</b>. All innovation is happening in Flamingock. Existing Mongock deployments migrate automatically — audit history is imported and previously executed changes are recognised as immutable historical records.
+<br><br>
+Read the full announcement: <a href="https://flamingock.io/blog/sunsetting-mongock/" target="_blank" rel="noopener">Sunsetting Mongock blog post</a>.
+</div>
+
+<div class="successAlt">
+<b>Ready to migrate? Move to Flamingock today.</b>
+<br><br>
+The transition is designed to be seamless — your existing ChangeUnits, audit history, and configuration carry over with minimal effort. You keep everything you built with Mongock and unlock a modern platform that governs stateful change across databases, APIs, event streams, and configuration stores.
+<br><br>
+Start on the migration guide now and join the growing community shipping with Flamingock: <a href="https://docs.flamingock.io/resources/coming-from-mongock" target="_blank" rel="noopener">Coming from Mongock →</a>
 </div>
 
 ## Introduction


### PR DESCRIPTION
- Wire GA4 tag (G-LJD5X6BDNH) into the shared layout head so tracking applies site-wide.
- Replace the "Mongock 5 released" banner on the landing page with a sunsetting notice pointing to Flamingock, plus a migration CTA linking to the Coming-from-Mongock guide and the sunsetting announcement post.
<img width="1504" height="788" alt="Screenshot 2026-07-04 at 15 39 45" src="https://github.com/user-attachments/assets/5b27b5c7-b476-4428-8e25-286ef5332062" />
