### PR TITLE
ci: fix gh-pages deploy and modernize workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,24 @@
 name: Eleventy Build
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Controls when the action will run. Triggers the workflow on push to master
 on:
   push:
     branches: [ master ]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:
-  # This workflow contains a single job called "build"
-  build:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+permissions:
+  contents: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Setup Node.js environment
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '14'
+        node-version: '22'
 
     - name: Install packages
       run: npm install
@@ -32,8 +27,8 @@ jobs:
       run: npm run build
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_site
         cname: docs.mongock.io


### PR DESCRIPTION
Switch peaceiris/actions-gh-pages to github_token auth so the workflow no longer depends on the ACTIONS_DEPLOY_KEY deploy key (which was failing with "Permission denied (publickey)"). Grant contents: write so GITHUB_TOKEN can push to gh-pages.

Also bump checkout, setup-node, and actions-gh-pages to current majors and move Node from 14 to 22, dropping ACTIONS_ALLOW_UNSECURE_COMMANDS.